### PR TITLE
Add `version` subcommand

### DIFF
--- a/cmd/ackdev/cmd/version.go
+++ b/cmd/ackdev/cmd/version.go
@@ -15,26 +15,28 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/version"
 )
 
-func init() {
-	rootCmd.AddCommand(listCmd)
-	rootCmd.AddCommand(versionCmd)
+const versionTmpl = `Date: %s
+Build: %s
+Version: %s
+Git Hash: %s
+`
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Args:  cobra.NoArgs,
+	RunE:  printVersion,
+	Short: "Print ackdev binary version informations",
 }
 
-var rootCmd = &cobra.Command{
-	Use:           "ackdev",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "A tool to manage ACK repositories, CRDs, development tools and testing",
-}
-
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+func printVersion(*cobra.Command, []string) error {
+	goVersion := fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Printf(versionTmpl, version.BuildDate, goVersion, version.GitVersion, version.GitCommit)
+	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,30 +11,10 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package cmd
+package version
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/spf13/cobra"
+var (
+	GitVersion string
+	GitCommit  string
+	BuildDate  string
 )
-
-func init() {
-	rootCmd.AddCommand(listCmd)
-	rootCmd.AddCommand(versionCmd)
-}
-
-var rootCmd = &cobra.Command{
-	Use:           "ackdev",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "A tool to manage ACK repositories, CRDs, development tools and testing",
-}
-
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-}


### PR DESCRIPTION
cherry pick from #1 

Changes:
- Implement `version` subcommand

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.