### PR TITLE
Add `config` package and implement `ackdev edit/get config` sub commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,58 @@ Call `ackdev help` for detailed usage instructions.
 
 ### Examples
 
+#### Manage ackdev configuration
+
+You can view the configuration used by ackdev by calling:
+
+```bash
+ackdev get config
+```
+
+The output will look like:
+
+```yaml
+rootDirectory: /home/amine/source/github.com/aws-controllers-k8s
+git:
+  sshKeyPath: /home/amine/.ssh/id_ed25519
+github:
+  token: somerandomtoken165489415631684131
+  username: A-Hilaly
+  forkPrefix: ack-
+repositories:
+  core:
+  - runtime
+  - community
+  - code-generator
+  - dev-tools
+  - test-infra
+  services:
+  - s3
+  - sns
+  - dynamodb
+  - ecr
+  - elasticache
+  - sagemaker
+  - sqs
+  - lambda
+run:
+  flags:
+    aws-account-id: "000000000000"
+    aws-region: eu-west-2
+    enable-development-logging: "true"
+    log-level: debug
+```
+
+To edit the configuration you can simply call:
+
+```
+ackdev edit config
+```
+
+by default this will open the configuration file using your OS default editor
+which is stored in the `EDITOR` environment variable. If this variable is not
+set `ackdev` will open the configuration using `vi`.
+
 #### List dependencies
 
 `ackdev` can help you manage dependencies and tools you will need in your ACK development journey.

--- a/cmd/ackdev/cmd/common.go
+++ b/cmd/ackdev/cmd/common.go
@@ -14,10 +14,33 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/olekukonko/tablewriter"
 )
+
+const (
+	ackdevConfigFileName = ".ackdev.yaml"
+)
+
+var (
+	homeDirectory     string
+	defaultConfigPath string
+)
+
+func init() {
+	// Set homeDirectory and defaultConfigPath
+	hd, err := homedir.Dir()
+	if err != nil {
+		fmt.Printf("unable to determine $HOME: %s\n", err)
+		os.Exit(1)
+	}
+	homeDirectory = hd
+	defaultConfigPath = filepath.Join(homeDirectory, ackdevConfigFileName)
+}
 
 func newTable() *tablewriter.Table {
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/ackdev/cmd/edit.go
+++ b/cmd/ackdev/cmd/edit.go
@@ -13,22 +13,31 @@
 
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultEditor = "vi"
+)
 
 var (
-	optListOutputFormat string
+	editor string
 )
 
 func init() {
-	listCmd.AddCommand(listDependenciesCmd)
-	listCmd.AddCommand(getConfigCmd)
+	editor = os.Getenv("EDITOR")
+	if editor == "" {
+		editor = defaultEditor
+	}
 
-	getConfigCmd.PersistentFlags().StringVarP(&optListOutputFormat, "output", "o", "yaml", "output format (json|yaml)")
+	editCmd.AddCommand(editConfigCmd)
 }
 
-var listCmd = &cobra.Command{
-	Use:     "list",
-	Aliases: []string{"get", "ls"},
-	Args:    cobra.NoArgs,
-	Short:   "Display one or many resources",
+var editCmd = &cobra.Command{
+	Use:   "edit",
+	Args:  cobra.NoArgs,
+	Short: "Edit a resource from the default editor.",
 }

--- a/cmd/ackdev/cmd/edit_config.go
+++ b/cmd/ackdev/cmd/edit_config.go
@@ -13,22 +13,31 @@
 
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+	"os/exec"
 
-var (
-	optListOutputFormat string
+	"github.com/spf13/cobra"
 )
 
-func init() {
-	listCmd.AddCommand(listDependenciesCmd)
-	listCmd.AddCommand(getConfigCmd)
-
-	getConfigCmd.PersistentFlags().StringVarP(&optListOutputFormat, "output", "o", "yaml", "output format (json|yaml)")
+var editConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Modify ackdev configuration file",
+	Args:  cobra.NoArgs,
+	RunE:  editConfig,
 }
 
-var listCmd = &cobra.Command{
-	Use:     "list",
-	Aliases: []string{"get", "ls"},
-	Args:    cobra.NoArgs,
-	Short:   "Display one or many resources",
+// editConfig opens ackdev configuration file in an editor. By default
+// opens the configuration file using vi.
+func editConfig(cmd *cobra.Command, args []string) error {
+	executable, err := exec.LookPath(editor)
+	if err != nil {
+		return err
+	}
+
+	c := exec.Command(executable, ackConfigPath)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
 }

--- a/cmd/ackdev/cmd/list_config.go
+++ b/cmd/ackdev/cmd/list_config.go
@@ -1,0 +1,57 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/config"
+)
+
+var getConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Display ackdev configuration file",
+	Args:  cobra.NoArgs,
+	RunE:  printConfig,
+}
+
+func printConfig(*cobra.Command, []string) error {
+	cfg, err := config.Load(ackConfigPath)
+	if err != nil {
+		return err
+	}
+
+	var b []byte
+	switch optListOutputFormat {
+	case "json":
+		b, err = json.Marshal(cfg)
+		if err != nil {
+			return err
+		}
+	case "yaml":
+		b, err = yaml.Marshal(cfg)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported output type: %s", optListOutputFormat)
+	}
+
+	fmt.Println(string(b))
+	return nil
+}

--- a/cmd/ackdev/cmd/root.go
+++ b/cmd/ackdev/cmd/root.go
@@ -20,8 +20,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	ackConfigPath string
+)
+
 func init() {
+	rootCmd.PersistentFlags().StringVar(&ackConfigPath, "config-file", defaultConfigPath, "ackdev configuration file path")
+
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(editCmd)
 	rootCmd.AddCommand(versionCmd)
 }
 

--- a/cmd/ackdev/cmd/version.go
+++ b/cmd/ackdev/cmd/version.go
@@ -15,26 +15,28 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/version"
 )
 
-func init() {
-	rootCmd.AddCommand(listCmd)
-	rootCmd.AddCommand(versionCmd)
+const versionTmpl = `Date: %s
+Build: %s
+Version: %s
+Git Hash: %s
+`
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Args:  cobra.NoArgs,
+	RunE:  printVersion,
+	Short: "Print ackdev binary version informations",
 }
 
-var rootCmd = &cobra.Command{
-	Use:           "ackdev",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "A tool to manage ACK repositories, CRDs, development tools and testing",
-}
-
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+func printVersion(*cobra.Command, []string) error {
+	goVersion := fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Printf(versionTmpl, version.BuildDate, goVersion, version.GitVersion, version.GitCommit)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/aws-controllers-k8s/dev-tools
 go 1.14
 
 require (
+	github.com/ghodss/yaml v1.0.0
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -100,8 +101,10 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -112,6 +115,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
@@ -279,6 +283,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
@@ -286,6 +291,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,120 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+)
+
+// Config is the ackdev global configuration. It contains information and default values
+// used by ackdev to manage local repositories, forks, dependencies, controllers...
+type Config struct {
+	// RootDirectory is the parent directory of the all ACK local repositories.
+	// If it's not specified ackdev will use $GOPATH/src/github.com/aws-controllers-k8s
+	RootDirectory string `yaml:"rootDirectory" json:"rootDirectory"`
+	// Git contains information used by ackdev to manage local git repositories.
+	Git GitConfig `yaml:"git" json:"git"`
+	// Github contains information used by ackdev to manage Github forks.
+	Github GithubConfig `yaml:"github" json:"github"`
+	// Repositories let you specify the Github/Local repositories ackdev should
+	// manage for you. By default ackdev manage all the core repositories (community,
+	// code-generator, test-infra, dev-tools and runtime).
+	Repositories RepositoriesConfig `yaml:"repositories" json:"repositories"`
+	// RunConfig let specify the arguments and flags used to run a controller locally,
+	// without having to build it image or deploy it into a cluster.
+	RunConfig RunConfig `yaml:"run" json:"run"`
+}
+
+// RepositoriesConfig represent repositories that are be managed by ackdev.
+type RepositoriesConfig struct {
+	// Core is the list of ACK core repositories. The default configuration contains:
+	// commmunity, code-generator, test-infra, dev-tools and runtime.
+	Core []string `yaml:"core" json:"core"`
+	// Services is the list of service controllers managed by ackdev.
+	Services []string `yaml:"services" json:"services"`
+}
+
+// GithubConfig represents the Github information needed to personal forks.
+type GithubConfig struct {
+	// Token is the token used to make Github API calls. This token needs at least
+	// the 'repo' scope. To generate this token please follow instructions in:
+	// https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+	Token string `yaml:"token" json:"token"`
+	// Username is the ackdev contributor Github username.
+	Username string `yaml:"username" json:"username"`
+	// ForkPrefix is the prefix prepended to the personal forks of ACK repositories.
+	// For example if ForkPrefix is 'ack-', ackdev will fork code-generator repository
+	// and rename to 'ack-code-generator.
+	ForkPrefix string `yaml:"forkPrefix" json:"forkPrefix"`
+}
+
+// Git contains information used by ackdev to manage local git repositories.
+type GitConfig struct {
+	// SSHKeyPath is the full path the SSH key used to clone Github repositories.
+	SSHKeyPath string `yaml:"sshKeyPath" json:"sshKeyPath"`
+}
+
+// RunConfig contains flags and arguments passed to service controllers binaries when
+// they are executed locally.
+type RunConfig struct {
+	// Flags is the map of flags/values passed to the controller binaries. For example
+	// to pass --aws-region=us-west-1 you'll need to set Flags to {"aws-region","us-west-1"}
+	Flags map[string]string `yaml:"flags" json:"flags"`
+}
+
+// DefaultConfig is the default configuration used to generated ackdev config
+var DefaultConfig = Config{
+	Repositories: RepositoriesConfig{
+		Core: []string{
+			"runtime",
+			"dev-tools",
+			"community",
+			"code-generator",
+			"test-infra",
+		},
+	},
+	Github: GithubConfig{
+		ForkPrefix: "ack-",
+	},
+}
+
+// Load reads a local configuration file and returns an ackdev configuration object.
+func Load(configPath string) (*Config, error) {
+	content, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := DefaultConfig
+	err = yaml.Unmarshal(content, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Save serialise a configuration object and writes it to given filepath.
+func Save(cfg *Config, filename string) error {
+	bytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil
+	}
+	err = ioutil.WriteFile(filename, bytes, 0777)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,30 +11,10 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package cmd
+package version
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/spf13/cobra"
+var (
+	GitVersion string
+	GitCommit  string
+	BuildDate  string
 )
-
-func init() {
-	rootCmd.AddCommand(listCmd)
-	rootCmd.AddCommand(versionCmd)
-}
-
-var rootCmd = &cobra.Command{
-	Use:           "ackdev",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Short:         "A tool to manage ACK repositories, CRDs, development tools and testing",
-}
-
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-}


### PR DESCRIPTION
Issue: N/A

Description:
- Implement `ackdev get config` command
- Implement `ackdev edit config` command
- Add a `config` package that contains methods to load and save ackdev configuration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.