### PR TITLE
Implement `ackdev setup` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,64 @@ go get github.com/aws-controllers-k8s/dev-tools/cmd/ackdev
 
 Call `ackdev help` for detailed usage instructions.
 
+### Setup
+
+To be able to use `ackdev` you'll have to run `ackdev setup` before any other command.
+
+For example
+```bash
+ackdev setup --root-directory $WORKDIR --services s3,ecr,sqs,sns
+```
+
+The setup command will simply create a yaml file named `$HOME/.ackdev.yaml`
+(you can choose a different file path `--config-file`)
+
+**NOTE**: If you are a contributor you probably want to leave `--root-directory` empty which will default to `$GOPATH/src/github.com/aws-controllers-k8s`
+(make sure that this directory exists).
+If you only want to test the tool, 
+We recommended you to set your `$WORKDIR` to a different directory.
+
+> Will my projects work/compile if I use a different directory than `$GOPATH/src/github.com/aws-controllers-k8s` ?
+
+Yes, even if it's not inside `GOPATH`, it will work as expected.
+Since Go 1.11.4 the Go compiler doesn't rely **entirely** on GOPATH to build projects.
+
+
+The generated configuration file will look like:
+
+``` yaml
+rootDirectory: /home/amine/go/source/github.com/aws-controllers-k8s/dev-tools
+git:
+  sshKeyPath: ""
+github:
+  token: ""
+  username: ""
+  forkPrefix: ""
+repositories:
+  core:
+  - runtime
+  - dev-tools
+  - community
+  - code-generator
+  services:
+  - s3
+  - ecr
+  - sns
+  - sqs
+run:
+  flags: {}
+```
+
+To use all `ackdev` features you will need to fill the `git.sshKeyPath` and `github` sections.
+You can do that using the `ackdev edit config` command,
+
+The `git.sshKeyPath` should point to the private key you use to push commits to your forks on Github.
+
+The `github.token` should contain a token that give `fork/renaming` permissions (`repo/*` policies).
+You can create one by following these [instructions][create-github-token].
+
+[create-github-token]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+
 ### Examples
 
 #### Manage ackdev configuration

--- a/cmd/ackdev/cmd/common.go
+++ b/cmd/ackdev/cmd/common.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 
@@ -27,8 +28,10 @@ const (
 )
 
 var (
-	homeDirectory     string
-	defaultConfigPath string
+	homeDirectory        string
+	defaultConfigPath    string
+	goPath               = build.Default.GOPATH
+	defaultRootDirectory = filepath.Join(goPath, "src/github.com/aws-controllers-k8s")
 )
 
 func init() {

--- a/cmd/ackdev/cmd/root.go
+++ b/cmd/ackdev/cmd/root.go
@@ -30,6 +30,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(editCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(setupCmd)
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/ackdev/cmd/setup.go
+++ b/cmd/ackdev/cmd/setup.go
@@ -1,0 +1,76 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/config"
+)
+
+var (
+	optSetupRootDirectory   string
+	optSetupInitialServices string
+)
+
+func init() {
+	setupCmd.PersistentFlags().StringVar(&optSetupRootDirectory, "root-directory", defaultRootDirectory, "root directory for ACK repositories")
+	setupCmd.PersistentFlags().StringVarP(&optSetupInitialServices, "services", "s", "", "services injected in the generated configuration file")
+}
+
+var setupCmd = &cobra.Command{
+	Use:     "setup",
+	RunE:    setupACKDev,
+	Args:    cobra.NoArgs,
+	Short:   "Generate ackdev configuration file",
+	Example: "ackdev setup --root-dir=. --services=s3,ecr,sqs",
+}
+
+func setupACKDev(cmd *cobra.Command, args []string) error {
+	_, err := config.Load(ackConfigPath)
+	if err == nil {
+		return fmt.Errorf("ackdev is already setup")
+	}
+
+	initialServices := strings.Split(optSetupInitialServices, ",")
+	rootDir, err := filepath.Abs(optSetupRootDirectory)
+	if err != nil {
+		return err
+	}
+
+	// Ensure that the root directory exists
+	err = os.MkdirAll(rootDir, os.ModePerm)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	newConfig := config.Config{
+		RootDirectory: rootDir,
+		Repositories: config.RepositoriesConfig{
+			Services: initialServices,
+			Core:     config.DefaultConfig.Repositories.Core,
+		},
+	}
+
+	err = config.Save(&newConfig, ackConfigPath)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Issue N/A

Description of changes:
- Implement `ackdev setup` command used to generate a minimal configuration file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
