### PR TITLE
Add `repository` package and implement `list repos` sub command

### DIFF
--- a/cmd/ackdev/cmd/list.go
+++ b/cmd/ackdev/cmd/list.go
@@ -21,6 +21,7 @@ var (
 
 func init() {
 	listCmd.AddCommand(listDependenciesCmd)
+	listCmd.AddCommand(listRepositoriesCmd)
 	listCmd.AddCommand(getConfigCmd)
 
 	getConfigCmd.PersistentFlags().StringVarP(&optListOutputFormat, "output", "o", "yaml", "output format (json|yaml)")

--- a/cmd/ackdev/cmd/list_repos.go
+++ b/cmd/ackdev/cmd/list_repos.go
@@ -1,0 +1,100 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/config"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/repository"
+)
+
+var (
+	listTableHeaderColumns = []string{"Name", "Type"}
+
+	optListFilterExpression string
+	optListShowBranch       bool
+)
+
+func init() {
+	listRepositoriesCmd.PersistentFlags().StringVarP(&optListFilterExpression, "filter", "f", "", "filter expression")
+	listRepositoriesCmd.PersistentFlags().BoolVar(&optListShowBranch, "show-branch", true, "display project current branch or not")
+}
+
+var listRepositoriesCmd = &cobra.Command{
+	Use:     "repository",
+	Aliases: []string{"repo", "repos", "repositories"},
+	RunE:    printRepositories,
+	Args:    cobra.NoArgs,
+}
+
+func printRepositories(cmd *cobra.Command, args []string) error {
+	filters, err := repository.BuildFilters(optListFilterExpression)
+	if err != nil {
+		return err
+	}
+
+	repos, err := listRepositories(filters...)
+	if err != nil {
+		return err
+	}
+
+	tablePrintRepositories(repos)
+	return nil
+}
+
+func listRepositories(filters ...repository.Filter) ([]*repository.Repository, error) {
+	cfg, err := config.Load(ackConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	repoManager, err := repository.NewManager(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try to load all repositories
+	err = repoManager.LoadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	// List repositories
+	//TODO(hilalymh) add sort-by flag/option
+	repos := repoManager.List(filters...)
+	if err != nil {
+		return nil, err
+	}
+	return repos, nil
+}
+
+func tablePrintRepositories(repos []*repository.Repository) {
+	tableHeaderColumns := listTableHeaderColumns
+	if optListShowBranch {
+		tableHeaderColumns = append(tableHeaderColumns, "Branch")
+	}
+
+	tw := newTable()
+	defer tw.Render()
+
+	tw.SetHeader(tableHeaderColumns)
+
+	for _, repo := range repos {
+		rawArgs := []string{repo.Name, repo.Type.String()}
+		if optListShowBranch {
+			rawArgs = append(rawArgs, repo.GitHead)
+		}
+		tw.Append(rawArgs)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/google/go-github/v33 v33.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.1.3
-	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
+	github.com/stretchr/testify v1.5.1
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -179,7 +180,10 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -202,6 +206,8 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
@@ -222,6 +228,8 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmV
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -276,6 +284,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -348,6 +357,7 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/pkg/repository/filter.go
+++ b/pkg/repository/filter.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrMalformatedFilterExpression error = errors.New("malformated filter expression")
+	ErrUnknownFilterKey            error = errors.New("unknown filter key")
+)
+
+// BuildFilters takes an expression string and returns a list
+// of Filter functions. Example: "branch=main type=controller"
+func BuildFilters(expression string) ([]Filter, error) {
+	expression = strings.TrimSpace(expression)
+	if len(expression) == 0 {
+		return []Filter{NoFilter}, nil
+	}
+
+	var filters []Filter
+	expressionElements := strings.Split(expression, " ")
+	for _, filterStr := range expressionElements {
+		// TODO(hilalymh) probably we can use a regular expression instead..
+		filterArgs := strings.Split(filterStr, "=")
+		if len(filterArgs) != 2 {
+			return nil, ErrMalformatedFilterExpression
+		}
+		key := strings.ToLower(filterArgs[0])
+		value := filterArgs[1]
+		switch key {
+		case "type":
+			filters = append(filters, TypeFilter(value))
+		case "name":
+			filters = append(filters, NameFilter(value))
+		case "branch":
+			filters = append(filters, BranchFilter(value))
+		default:
+			return nil, fmt.Errorf("unknown filter key: %s", key)
+		}
+	}
+	return filters, nil
+}
+
+// A Filter is a prototype for a function that can be used to filter the
+// results from a call to the List() method on the Manager.
+type Filter func(r *Repository) bool
+
+// NoFilter will not filter out any repository.
+func NoFilter(r *Repository) bool { return true }
+
+// NameFilter filters all repositories whose names matches the specified name
+func NameFilter(name string) Filter {
+	return func(r *Repository) bool {
+		return r.Name == name
+	}
+}
+
+// NamePrefixFilter filters all repositories whose name prefix matches the
+// the given namePrefix
+func NamePrefixFilter(namePrefix string) Filter {
+	return func(r *Repository) bool {
+		return strings.HasPrefix(r.Name, namePrefix)
+	}
+}
+
+// TypeFilter filters a repository by a name prefix
+// The only two possible types are 'controller' and 'core'
+func TypeFilter(t string) Filter {
+	return func(r *Repository) bool {
+		return r.Type == repositoryTypeFromString(t)
+	}
+}
+
+// BranchFilter filters all repositories whose current branch matches the
+// given branch name.
+func BranchFilter(branch string) Filter {
+	return func(r *Repository) bool {
+		return r.GitHead == branch
+	}
+}

--- a/pkg/repository/filter_test.go
+++ b/pkg/repository/filter_test.go
@@ -1,0 +1,142 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildFilters(t *testing.T) {
+	assert := assert.New(t)
+
+	type args struct {
+		expression string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantLenFilter int
+		wantErr       bool
+	}{
+		{
+			name:          "empty expression",
+			args:          args{expression: "    "},
+			wantLenFilter: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "malformated expression - empty key",
+			args:          args{expression: "key=value =value"},
+			wantLenFilter: 0,
+			wantErr:       true,
+		},
+		{
+			name:          "malformated expression - empty value",
+			args:          args{expression: "key=value key="},
+			wantLenFilter: 0,
+			wantErr:       true,
+		},
+		{
+			name:          "unkown filter key",
+			args:          args{expression: "name=runtime somekey=value"},
+			wantLenFilter: 0,
+			wantErr:       true,
+		},
+		{
+			name:          "correct expression",
+			args:          args{expression: "type=core"},
+			wantLenFilter: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "correct expression - all filters",
+			args:          args{expression: "type=core branch=main name=runtime"},
+			wantLenFilter: 3,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filters, err := BuildFilters(tt.args.expression)
+			if (err != nil) != tt.wantErr {
+				assert.Fail(fmt.Sprintf("BuildFilters() error = %v, wantErr %v", err, tt.wantErr))
+			}
+			assert.Len(filters, tt.wantLenFilter)
+		})
+	}
+}
+
+func TestNoFilter(t *testing.T) {
+	repo := &Repository{}
+	assert.True(t, NoFilter(repo))
+	assert.True(t, NoFilter(nil))
+}
+
+func TestNameFilter(t *testing.T) {
+	nameFilter := NameFilter("runtime")
+	runtimeRepo := &Repository{
+		Name: "runtime",
+	}
+	sqsRepo := &Repository{
+		Name: "sqs",
+	}
+	assert.True(t, nameFilter(runtimeRepo))
+	assert.False(t, nameFilter(sqsRepo))
+}
+
+func TestNamePrefixFilter(t *testing.T) {
+	namePrefixfilter := NamePrefixFilter("com")
+	runtimeRepo := &Repository{
+		Name: "runtime",
+	}
+	communityRepo := &Repository{
+		Name: "community",
+	}
+	assert.False(t, namePrefixfilter(runtimeRepo))
+	assert.True(t, namePrefixfilter(communityRepo))
+}
+
+func TestTypeFilter(t *testing.T) {
+	repoTypeFilter := TypeFilter(RepositoryTypeCore.String())
+	runtimeRepo := &Repository{
+		Name: "runtime",
+		Type: RepositoryTypeCore,
+	}
+	sqsRepo := &Repository{
+		Name: "sqs",
+		Type: RepositoryTypeController,
+	}
+	assert.True(t, repoTypeFilter(runtimeRepo))
+	assert.False(t, repoTypeFilter(sqsRepo))
+}
+
+func TestBranchFilter(t *testing.T) {
+	branchFilter := BranchFilter("main")
+	runtimeRepo := &Repository{
+		Name:    "runtime",
+		GitHead: "main",
+		Type:    RepositoryTypeCore,
+	}
+	sqsRepo := &Repository{
+		Name:    "sqs",
+		GitHead: "feature-xyz",
+		Type:    RepositoryTypeController,
+	}
+	assert.True(t, branchFilter(runtimeRepo))
+	assert.False(t, branchFilter(sqsRepo))
+}

--- a/pkg/repository/manager.go
+++ b/pkg/repository/manager.go
@@ -1,0 +1,340 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	git "gopkg.in/src-d/go-git.v4"
+	gitconfig "gopkg.in/src-d/go-git.v4/config"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/config"
+	ackdevgit "github.com/aws-controllers-k8s/dev-tools/pkg/git"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/github"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/util"
+)
+
+const (
+	originRemoteName   = "origin"
+	upstreamRemoteName = "upstream"
+)
+
+var (
+	ErrUnauthenticated        error = errors.New("unauthenticated")
+	ErrUnconfiguredRepository error = errors.New("unconfigured repository")
+	ErrRepositoryNotCached    error = errors.New("repository not cached")
+	ErrRepositoryDoesntExist  error = errors.New("repository doesnt exist")
+	ErrRepositoryAlreadyExist error = errors.New("repository already exist")
+)
+
+// NewManager create a new manager.
+func NewManager(cfg *config.Config) (*Manager, error) {
+	githubClient := github.NewClient(cfg.Github.Token)
+	gitOpts := []ackdevgit.Option{
+		ackdevgit.WithRemote(originRemoteName),
+	}
+	urlBuilder := httpsRemoteURL
+
+	// Add git authentication options
+	if cfg.Git.SSHKeyPath == "" {
+		gitOpts = append(gitOpts,
+			ackdevgit.WithGithubCredentials(cfg.Github.Username, cfg.Github.Token),
+		)
+	} else {
+		// TODO(hilalymh) set ssh.Signer here.. figure out how to deal with encrypted
+		// keys properly...
+		gitOpts = append(gitOpts, ackdevgit.WithSSHSigner(nil))
+		urlBuilder = sshRemoteURL
+	}
+
+	gitClient := ackdevgit.New(gitOpts...)
+
+	return &Manager{
+		repoCache: make(map[string]*Repository),
+
+		cfg:        cfg,
+		ghc:        githubClient,
+		git:        gitClient,
+		urlBuilder: urlBuilder,
+	}, nil
+}
+
+// Manager is reponsible of managing local ACK local repositories and
+// github forks.
+type Manager struct {
+	repoCache map[string]*Repository
+
+	log        *logrus.Logger
+	cfg        *config.Config
+	git        ackdevgit.OpenCloner
+	ghc        github.RepositoryService
+	urlBuilder func(owner, repo string) string
+}
+
+// LoadRepository loads information about a single local repository
+func (m *Manager) LoadRepository(name string, t RepositoryType) (*Repository, error) {
+	// check repo cache
+	repo, err := m.GetRepository(name)
+	if err == nil {
+		return repo, nil
+	}
+
+	// fail if repository doesn't exist in the manager configuration
+	switch t {
+	case RepositoryTypeCore:
+		if !util.InStrings(name, m.cfg.Repositories.Core) {
+			return nil, ErrUnconfiguredRepository
+		}
+	case RepositoryTypeController:
+		if !util.InStrings(name, m.cfg.Repositories.Services) {
+			return nil, ErrUnconfiguredRepository
+		}
+	}
+
+	repoName := name
+	// controller repositories should always have a '-controller' suffix
+	if t == RepositoryTypeController {
+		repoName = fmt.Sprintf("%s-controller", name)
+	}
+
+	// set expected fork name
+	expectedForkName := repoName
+	if m.cfg.Github.ForkPrefix != "" {
+		expectedForkName = fmt.Sprintf("%s%s", m.cfg.Github.ForkPrefix, repoName)
+	}
+
+	var gitHead string
+	var gitRepo *git.Repository
+	fullPath := filepath.Join(m.cfg.RootDirectory, repoName)
+
+	gitRepo, err = m.git.Open(fullPath)
+	if err != nil && err != git.ErrRepositoryNotExists {
+		return nil, err
+	} else if err == nil {
+		// load current branch
+		head, err := gitRepo.Head()
+		if err != nil {
+			return nil, err
+		}
+		gitHead = head.Name().Short()
+	}
+
+	repo = &Repository{
+		Name:             repoName,
+		Type:             t,
+		gitRepo:          gitRepo,
+		GitHead:          gitHead,
+		FullPath:         fullPath,
+		ExpectedForkName: expectedForkName,
+	}
+
+	// cache repository
+	m.repoCache[name] = repo
+	return repo, nil
+}
+
+// LoadAll parses the configuration and loads informations about local
+// repositories if they are found.
+func (m *Manager) LoadAll() error {
+	// collect repositories from config
+	for _, coreRepo := range m.cfg.Repositories.Core {
+		_, err := m.LoadRepository(coreRepo, RepositoryTypeCore)
+		if err != nil {
+			return err
+		}
+	}
+	for _, serviceName := range m.cfg.Repositories.Services {
+		_, err := m.LoadRepository(serviceName, RepositoryTypeController)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetRepository return a known repository
+func (m *Manager) GetRepository(repoName string) (*Repository, error) {
+	repo, ok := m.repoCache[repoName]
+	if !ok {
+		return nil, ErrRepositoryNotCached
+	}
+	return repo, nil
+}
+
+// List returns the list of all the cached repositories
+func (m *Manager) List(filters ...Filter) []*Repository {
+	repos := []*Repository{}
+	repoNames := append(m.cfg.Repositories.Core, m.cfg.Repositories.Services...)
+mainLoop:
+	for _, repoName := range repoNames {
+		repo, err := m.GetRepository(repoName)
+		if err != nil {
+			continue
+		}
+		for _, filter := range filters {
+			if !filter(repo) {
+				continue mainLoop
+			}
+		}
+		repos = append(repos, repo)
+	}
+	return repos
+}
+
+// Clone clones a known repository to the config root directory
+func (m *Manager) clone(ctx context.Context, repoName string) error {
+	repo, err := m.GetRepository(repoName)
+	if err != nil {
+		return fmt.Errorf("cannot clone repository %s: %v", repoName, err)
+	}
+	if repo.gitRepo != nil {
+		return ErrRepositoryAlreadyExist
+	}
+
+	// clone fork repository
+	err = m.git.Clone(
+		ctx,
+		m.urlBuilder(m.cfg.Github.Username, repo.ExpectedForkName),
+		repo.ExpectedForkName,
+	)
+	if errors.Is(err, transport.ErrAuthenticationRequired) {
+		return ErrUnauthenticated
+	}
+	if err != nil {
+		return fmt.Errorf("cannot clone repository %s: %v", repoName, err)
+	}
+
+	// open git repository
+	gitRepo, err := m.git.Open(repo.FullPath)
+	if err != nil {
+		// Maybe panic here?
+		return err
+	}
+
+	// set repository git object
+	repo.gitRepo = gitRepo
+
+	// Add upstream remote
+	_, err = gitRepo.CreateRemote(&gitconfig.RemoteConfig{
+		Name: upstreamRemoteName,
+		URLs: []string{m.urlBuilder(github.ACKOrg, repo.Name)},
+	})
+
+	if err != nil {
+		return fmt.Errorf("cannot add upstream remote to repository %s: %v", repoName, err)
+	}
+
+	return nil
+}
+
+// ensureFork ensures that your github account have a fork for a given
+// ACK project. It will also rename the project if it's not following the
+// standard: $ackprefix-$projectname
+func (m *Manager) EnsureFork(ctx context.Context, repo *Repository) error {
+	// TODO(hilaly): m.log.SetLevel(logrus.DebugLevel)
+
+	fork, err := m.ghc.GetUserRepositoryFork(ctx, repo.Name)
+	if err == nil {
+		if *fork.Name != repo.ExpectedForkName {
+			err = m.ghc.RenameRepository(ctx, m.cfg.Github.Username, *fork.Name, repo.ExpectedForkName)
+			if err != nil {
+				return err
+			}
+		}
+	} else if err == github.ErrorForkNotFound {
+		err = m.ghc.ForkRepository(ctx, repo.Name)
+		if err != nil {
+			return err
+		}
+
+		time.Sleep(1 * time.Second)
+
+		err = m.ghc.RenameRepository(ctx, m.cfg.Github.Username, repo.Name, repo.ExpectedForkName)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return err
+}
+
+// used to help mocking os.Rename
+// TODO(hilalymh): Q4 switch to go1.16 os/fs library/interface
+var renameDirectory = os.Rename
+
+func (m *Manager) EnsureClone(ctx context.Context, repo *Repository) error {
+	err := m.clone(ctx, repo.Name)
+	if err != nil && err != ErrRepositoryAlreadyExist {
+		return err
+	}
+
+	// At this point we ensured that the fork repository is cloned. We need to rename it
+	// if there is any fork prefix.
+	if repo.Name != repo.ExpectedForkName {
+
+		newPath := filepath.Join(
+			filepath.Dir(repo.FullPath),
+			repo.Name,
+		)
+		err := renameDirectory(repo.FullPath, newPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// EnsureAll ensures one repository.
+func (m *Manager) EnsureRepository(ctx context.Context, name string) error {
+	repo, err := m.GetRepository(name)
+	if err != nil {
+		return err
+	}
+
+	err = m.EnsureFork(ctx, repo)
+	if err != nil {
+		return err
+	}
+
+	err = m.EnsureClone(ctx, repo)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// EnsureAll ensures all cached repositories.
+func (m *Manager) EnsureAll(ctx context.Context) error {
+	for _, repo := range m.repoCache {
+		err := m.EnsureFork(ctx, repo)
+		if err != nil {
+			return err
+		}
+
+		err = m.EnsureClone(ctx, repo)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/repository/manager_test.go
+++ b/pkg/repository/manager_test.go
@@ -1,0 +1,446 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	gogithub "github.com/google/go-github/v33/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4"
+	gitconfig "gopkg.in/src-d/go-git.v4/config"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/config"
+	ackdevgit "github.com/aws-controllers-k8s/dev-tools/pkg/git"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/github"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/testutil"
+
+	"github.com/aws-controllers-k8s/dev-tools/mocks"
+)
+
+var (
+	testingCtx = context.TODO()
+)
+
+func stringPtr(s string) *string { return &s }
+
+func TestManager_LoadRepository(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	testRepo, err := testutil.NewInMemoryGitRepository()
+	require.NoError(err)
+
+	fakeGit := &mocks.OpenCloner{}
+	fakeGit.On("Open", "runtime").Return(testRepo, nil)
+	fakeGit.On("Open", "s3-controller").Return(nil, git.ErrRepositoryNotExists)
+	fakeGit.On("Open", "sqs-controller").Return(nil, ErrUnconfiguredRepository)
+
+	type fields struct {
+		cfg       *config.Config
+		git       ackdevgit.OpenCloner
+		repoCache map[string]*Repository
+	}
+	type args struct {
+		name string
+		t    RepositoryType
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *Repository
+		wantErr bool
+	}{
+		{
+			name: "repository exists",
+			fields: fields{
+				cfg:       testutil.NewConfig(),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				name: "runtime",
+				t:    RepositoryTypeCore,
+			},
+			wantErr: false,
+		},
+		{
+			name: "repository doesn't exists",
+			fields: fields{
+				cfg:       testutil.NewConfig(),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				name: "s3",
+				t:    RepositoryTypeController,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unconfigured repository",
+			fields: fields{
+				cfg:       testutil.NewConfig(),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				name: "sqs",
+				t:    RepositoryTypeController,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{
+				cfg:       tt.fields.cfg,
+				git:       tt.fields.git,
+				repoCache: tt.fields.repoCache,
+			}
+			_, err := m.LoadRepository(tt.args.name, tt.args.t)
+			if (err != nil) != tt.wantErr {
+				assert.Fail(fmt.Sprintf("Manager.LoadRepository() error = %v, wantErr %v", err, tt.wantErr))
+			}
+		})
+	}
+}
+
+func TestManager_LoadAll(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	testRepo, err := testutil.NewInMemoryGitRepository()
+	require.NoError(err)
+
+	fakeGit := &mocks.OpenCloner{}
+	fakeGit.On("Open", "runtime").Return(testRepo, nil)
+	fakeGit.On("Open", "code-generator").Return(testRepo, nil)
+	fakeGit.On("Open", "s3-controller").Return(nil, git.ErrRepositoryNotExists)
+	fakeGit.On("Open", "ecr-controller").Return(nil, bytes.ErrTooLarge)
+	fakeGit.On("Open", "sagemaker-controller").Return(nil, bytes.ErrTooLarge)
+
+	type fields struct {
+		cfg       *config.Config
+		git       ackdevgit.OpenCloner
+		repoCache map[string]*Repository
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "all repositories exists",
+			fields: fields{
+				cfg:       testutil.NewConfig(),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			wantErr: false,
+		},
+		{
+			name: "repository not found",
+			fields: fields{
+				cfg:       testutil.NewConfig("s3"),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			wantErr: false,
+		},
+		{
+			name: "unexpected repository error",
+			fields: fields{
+				cfg:       testutil.NewConfig("ecr", "sagemaker"),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{
+				cfg:       tt.fields.cfg,
+				git:       tt.fields.git,
+				repoCache: tt.fields.repoCache,
+			}
+			err := m.LoadAll()
+			if (err != nil) != tt.wantErr {
+				assert.Fail(fmt.Sprintf("Manager.LoadAll() error = %v, wantErr %v", err, tt.wantErr))
+			}
+		})
+	}
+}
+
+func TestManager_clone(t *testing.T) {
+	//assert := assert.New(t)
+	require := require.New(t)
+
+	testRepo, err := testutil.NewInMemoryGitRepository()
+	require.NoError(err)
+
+	fakeGit := &mocks.OpenCloner{}
+	fakeGit.On("Open", "s3-controller").Return(testRepo, nil)
+	fakeGit.On("Open", "mq-controller").Return(nil, git.ErrRepositoryNotExists)
+	fakeGit.On("Open", "ecr-controller").Return(nil, git.ErrRepositoryNotExists)
+	fakeGit.On("Open", "sagemaker-controller").Return(nil, git.ErrRepositoryNotExists).Once()
+	fakeGit.On("Open", "sagemaker-controller").Return(testRepo, nil).Once()
+
+	fakeGit.On(
+		"Clone",
+		testingCtx,
+		"https://github.com/ack-bot/ack-ecr-controller.git",
+		"ack-ecr-controller",
+	).Return(transport.ErrAuthenticationRequired)
+	fakeGit.On(
+		"Clone",
+		testingCtx,
+		"https://github.com/ack-bot/ack-mq-controller.git",
+		"ack-mq-controller",
+	).Return(gitconfig.ErrRemoteConfigNotFound)
+	fakeGit.On(
+		"Clone",
+		testingCtx,
+		"https://github.com/ack-bot/ack-sagemaker-controller.git",
+		"ack-sagemaker-controller",
+	).Return(nil)
+
+	type fields struct {
+		cfg        *config.Config
+		ghc        github.RepositoryService
+		git        ackdevgit.OpenCloner
+		urlBuilder func(string, string) string
+		repoCache  map[string]*Repository
+	}
+	type args struct {
+		repoName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "repository not configured",
+			fields: fields{
+				cfg:       testutil.NewConfig(),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				repoName: "dynamodb",
+			},
+			wantErr: true,
+		},
+		{
+			name: "repository already exists",
+			fields: fields{
+				cfg:       testutil.NewConfig("s3", "elasticache"),
+				git:       fakeGit,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				repoName: "s3",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unauthenticated git",
+			fields: fields{
+				cfg:        testutil.NewConfig("s3", "elasticache"),
+				git:        fakeGit,
+				urlBuilder: httpsRemoteURL,
+				repoCache:  make(map[string]*Repository),
+			},
+			args: args{
+				repoName: "ecr",
+			},
+			wantErr: true,
+		},
+		{
+			name: "cloning error",
+			fields: fields{
+				cfg:        testutil.NewConfig("mq"),
+				git:        fakeGit,
+				urlBuilder: httpsRemoteURL,
+				repoCache:  make(map[string]*Repository),
+			},
+			args: args{
+				repoName: "mq",
+			},
+			wantErr: true,
+		},
+		{
+			name: "cloning successful",
+			fields: fields{
+				cfg:        testutil.NewConfig("sagemaker"),
+				git:        fakeGit,
+				urlBuilder: httpsRemoteURL,
+				repoCache:  make(map[string]*Repository),
+			},
+			args: args{
+				repoName: "sagemaker",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{
+				cfg:        tt.fields.cfg,
+				ghc:        tt.fields.ghc,
+				git:        tt.fields.git,
+				urlBuilder: tt.fields.urlBuilder,
+				repoCache:  tt.fields.repoCache,
+			}
+			_, _ = m.LoadRepository(tt.args.repoName, RepositoryTypeController)
+			if err := m.clone(testingCtx, tt.args.repoName); (err != nil) != tt.wantErr {
+				t.Errorf("Manager.clone() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestManager_EnsureFork(t *testing.T) {
+	fakeGithubClient := &mocks.RepositoryService{}
+	// s3 case
+	fakeGithubClient.On(
+		"GetUserRepositoryFork",
+		testingCtx,
+		"s3-controller",
+	).Return(nil, github.ErrorForkNotFound)
+	fakeGithubClient.On(
+		"ForkRepository",
+		testingCtx,
+		"s3-controller",
+	).Return(errors.New("unknown error"))
+
+	// sagemaker case
+	fakeGithubClient.On(
+		"GetUserRepositoryFork",
+		testingCtx,
+		"sagemaker-controller",
+	).Return(&gogithub.Repository{Name: stringPtr("sagemaker-controller")}, nil)
+	fakeGithubClient.On(
+		"RenameRepository",
+		testingCtx,
+		"ack-bot",
+		"sagemaker-controller",
+		"ack-sagemaker-controller",
+	).Return(nil)
+
+	// ecr case
+	fakeGithubClient.On(
+		"GetUserRepositoryFork",
+		testingCtx,
+		"ecr-controller",
+	).Return(nil, github.ErrorForkNotFound)
+	fakeGithubClient.On(
+		"ForkRepository",
+		testingCtx,
+		"ecr-controller",
+	).Return(nil)
+	fakeGithubClient.On(
+		"RenameRepository",
+		testingCtx,
+		"ack-bot",
+		"ecr-controller",
+		"ack-ecr-controller",
+	).Return(nil)
+
+	type fields struct {
+		cfg       *config.Config
+		ghc       github.RepositoryService
+		git       ackdevgit.OpenCloner
+		repoCache map[string]*Repository
+	}
+	type args struct {
+		repo *Repository
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "fork error",
+			fields: fields{
+				cfg:       testutil.NewConfig("s3"),
+				ghc:       fakeGithubClient,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				repo: &Repository{
+					Name:             "s3-controller",
+					ExpectedForkName: "s3-sagemaker-controller",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "ensure fork successful - rename",
+			fields: fields{
+				cfg:       testutil.NewConfig("sagemaker"),
+				ghc:       fakeGithubClient,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				repo: &Repository{
+					Name:             "sagemaker-controller",
+					ExpectedForkName: "ack-sagemaker-controller",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure fork successful - fork and rename",
+			fields: fields{
+				cfg:       testutil.NewConfig("ecr"),
+				ghc:       fakeGithubClient,
+				repoCache: make(map[string]*Repository),
+			},
+			args: args{
+				repo: &Repository{
+					Name:             "ecr-controller",
+					ExpectedForkName: "ack-ecr-controller",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{
+				cfg:       tt.fields.cfg,
+				ghc:       tt.fields.ghc,
+				git:       tt.fields.git,
+				repoCache: tt.fields.repoCache,
+			}
+			if err := m.EnsureFork(testingCtx, tt.args.repo); (err != nil) != tt.wantErr {
+				t.Errorf("Manager.ensureFork() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,0 +1,56 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-git.v4"
+)
+
+// NewRepository returns a pointer to a new repository.
+func NewRepository(name string, repoType RepositoryType) *Repository {
+	if repoType == RepositoryTypeController {
+		name = fmt.Sprintf("%s-controller", name)
+	}
+	return &Repository{
+		Name: name,
+		Type: repoType,
+	}
+}
+
+// Repository represents an ACK project repository.
+type Repository struct {
+	// this field might be nil, if the repository doesn't exist locally
+	gitRepo *git.Repository
+
+	// Name of the ACK upstream repo
+	Name string
+	// Repository Type
+	Type RepositoryType
+	// Expected fork name. Generally looking like ack-sagemaker
+	ExpectedForkName string
+	// Expected local full path
+	FullPath string
+	// Git HEAD commit or current branch
+	GitHead string
+}
+
+func httpsRemoteURL(owner, name string) string {
+	return fmt.Sprintf("https://github.com/%s/%s.git", owner, name)
+}
+
+func sshRemoteURL(owner, name string) string {
+	return fmt.Sprintf("git@github.com:%s/%s.git", owner, name)
+}

--- a/pkg/repository/sort.go
+++ b/pkg/repository/sort.go
@@ -1,0 +1,80 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+import "sort"
+
+// Gently stolen from github.com/aws-controllers-k8s/code-generator/pkg/model/printer_column.go
+
+// By can sort two Repositories
+type By func(a, b *Repository) bool
+
+// Sort does an in-place sort of the supplied repositories
+func (by By) Sort(subject []*Repository) {
+	pcs := repositorySorter{
+		cols: subject,
+		by:   by,
+	}
+	sort.Sort(pcs)
+}
+
+// repositorySorter sorts repositories
+type repositorySorter struct {
+	cols []*Repository
+	by   By
+}
+
+// Len implements sort.Interface.Len
+func (pcs repositorySorter) Len() int {
+	return len(pcs.cols)
+}
+
+// Swap implements sort.Interface.Swap
+func (pcs repositorySorter) Swap(i, j int) {
+	pcs.cols[i], pcs.cols[j] = pcs.cols[j], pcs.cols[i]
+}
+
+// Less implements sort.Interface.Less
+func (pcs repositorySorter) Less(i, j int) bool {
+	return pcs.by(pcs.cols[i], pcs.cols[j])
+}
+
+// Sort two repositories by name
+func ByName(a, b *Repository) bool {
+	return a.Name < b.Name
+}
+
+// Sort two repositories by branch
+func ByBranch(a, b *Repository) bool {
+	return a.GitHead < b.GitHead
+}
+
+// Sort two repositories by type
+func ByType(a, b *Repository) bool {
+	return a.Type < b.Type
+}
+
+// SortBy takes a field path and returns the equivalent Sorter function
+func SortBy(fieldPath string) By {
+	switch fieldPath {
+	case "name":
+		return ByName
+	case "branch":
+		return ByBranch
+	case "type":
+		return ByType
+	default:
+		panic("unknown sort field")
+	}
+}

--- a/pkg/repository/type.go
+++ b/pkg/repository/type.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+type RepositoryType int
+
+const (
+	RepositoryTypeCore RepositoryType = iota
+	RepositoryTypeTooling
+	RepositoryTypeController
+	RepositoryTypeUnknown
+)
+
+// String stringifies a Repository type
+func (rt RepositoryType) String() string {
+	switch rt {
+	case RepositoryTypeCore:
+		return "core"
+	case RepositoryTypeController:
+		return "controller"
+	case RepositoryTypeUnknown:
+		return "UNKNOWN"
+	default:
+		panic("unsupported repository type")
+	}
+}
+
+// repositoryTypeFromString casts a string to a RepositoryType
+func repositoryTypeFromString(s string) RepositoryType {
+	switch s {
+	case "core":
+		return RepositoryTypeCore
+	case "controller":
+		return RepositoryTypeController
+	default:
+		panic("unsupported repository type")
+	}
+}

--- a/pkg/testutil/config.go
+++ b/pkg/testutil/config.go
@@ -1,0 +1,33 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutil
+
+import "github.com/aws-controllers-k8s/dev-tools/pkg/config"
+
+// Returns a new config.Config object used for testing purposes.
+func NewConfig(services ...string) *config.Config {
+	return &config.Config{
+		Repositories: config.RepositoriesConfig{
+			Core: []string{
+				"runtime",
+				"code-generator",
+			},
+			Services: services,
+		},
+		Github: config.GithubConfig{
+			ForkPrefix: "ack-",
+			Username:   "ack-bot",
+		},
+	}
+}

--- a/pkg/testutil/git.go
+++ b/pkg/testutil/git.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutil
+
+import (
+	"gopkg.in/src-d/go-billy.v4/memfs"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/storage/memory"
+)
+
+// NewInMemoryGitRepository returns a in-memory git repository containing one commit.
+func NewInMemoryGitRepository() (*git.Repository, error) {
+	fs := memfs.New()
+	store := memory.NewStorage()
+	repo, err := git.Init(store, fs)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := fs.Create("ramanujan_serie.txt")
+	if err != nil {
+		return nil, err
+	}
+	_, err = file.Write([]byte("1 + 2 + 3 + 4 + ... = -1/12"))
+	if err != nil {
+		return nil, err
+	}
+	err = file.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	_, err = w.Add("ramanujan_serie.txt")
+	if err != nil {
+		return nil, err
+	}
+
+	commit, err := w.Commit("first commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Srinivasa Ramanujan",
+			Email: "sramanujan@1729",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	_, err = repo.CommitObject(commit)
+	if err != nil {
+		return nil, err
+	}
+	return repo, nil
+}

--- a/pkg/util/pem.go
+++ b/pkg/util/pem.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// newSigner returns a ssh.Signer from a PEM encoded private key path.
+// If the PEM file is encrypted it will try to read the passphrase from
+// a terminal without local echo.
+func NewSigner(sshKeyPath string) (ssh.Signer, error) {
+	pemBytes, err := ioutil.ReadFile(sshKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("invalid ssh certificate")
+	}
+
+	if encryptedBlock(block) {
+		passphrase, err := promptPassphrase()
+		if err != nil {
+			return nil, err
+		}
+
+		return ssh.ParsePrivateKeyWithPassphrase(pemBytes, passphrase)
+	}
+
+	return ssh.ParsePrivateKey(pemBytes)
+}
+
+// encryptedBlock tells whether a private key is
+// encrypted by examining its Proc-Type header
+// for a mention of ENCRYPTED
+// according to RFC 1421 Section 4.6.1.1.
+func encryptedBlock(block *pem.Block) bool {
+	return strings.Contains(block.Headers["Proc-Type"], "ENCRYPTED")
+}
+
+func promptPassphrase() ([]byte, error) {
+	fmt.Printf("type your ssh key passphrase:")
+	passphrase, err := terminal.ReadPassword(0)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(hilalymh): retry + validation mechanisms.
+	return passphrase, nil
+}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+// InStrings returns true if the subject string is contained in the supplied
+// slice of strings
+// Gently copied from github.com/aws-controllers-k8s/runtime/pkg/util
+func InStrings(subject string, collection []string) bool {
+	for _, item := range collection {
+		if subject == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Issue N/A

Description of changes:
- Add `util` package: string utils
- Add `testutil` package: fake in-memory git repositories + fake ackdev config
- Add `repository` package: Adding functionality to
  - Forks `ACK` Github repositories and rename personal ones
  - Clone and Read local/configured repositories
  - List local repositories with filter/sort options
- Add `list repos` sub command
- Update go.mod with `go mod tidy`

Examples output:
```bash
$ ackdev list repos

NAME                    TYPE       BRANCH     
runtime                 core       main       
community               core       tests      
code-generator          core       delta-maps 
dev-tools               core       repos      
test-infra              core       main       
s3-controller           controller main       
sns-controller          controller main       
dynamodb-controller     controller main       
ecr-controller          controller test       
elasticache-controller  controller main       
sagemaker-controller    controller main       
rds-controller          controller main       
apigatewayv2-controller controller main       
mq-controller           controller main
```

```bash
$ ackdev list repos --filter "type=controller branch=main"

NAME                    TYPE       BRANCH 
s3-controller           controller main   
sns-controller          controller main   
dynamodb-controller     controller main   
elasticache-controller  controller main   
sagemaker-controller    controller main   
rds-controller          controller main   
apigatewayv2-controller controller main   
mq-controller           controller main
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
