### PR TITLE
Fix unit-tests workflow `run-on` variable

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   unit-tests:
     name: make test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go-version:


### PR DESCRIPTION
Github actions were always running test on the same OS (ubuntu). This patch fixes that and allows unit tests to run on all different `matrix.os` values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
