### PR TITLE
remove `./ackdev` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-./ackdev
 ./config.yaml
 ./test.yaml
 bin


### PR DESCRIPTION
Issue N/A

Description of changes:
- remove `./ackdev` from gitignore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
