### PR TITLE
Added the add repository command

### DIFF
--- a/cmd/ackdev/cmd/add.go
+++ b/cmd/ackdev/cmd/add.go
@@ -1,0 +1,27 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+func init() {
+	addCmd.AddCommand(addRepositoryCmd)
+}
+
+var addCmd = &cobra.Command{
+	Use:     "add",
+	Aliases: []string{},
+	Args:    cobra.NoArgs,
+	Short:   "Creates one or more resources",
+}

--- a/cmd/ackdev/cmd/add_repo.go
+++ b/cmd/ackdev/cmd/add_repo.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/config"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/repository"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ErrRepositoryAlreadyAdded = errors.New("repository has already been added")
+)
+
+var addRepositoryCmd = &cobra.Command{
+	Use:     "repository <service> ...",
+	Aliases: []string{"repo", "repos", "repository", "repositories"},
+	RunE:    addRepository,
+	Args:    cobra.MinimumNArgs(1),
+}
+
+func addRepository(cmd *cobra.Command, args []string) error {
+	for _, service := range args {
+		service = strings.ToLower(args[0])
+
+		ctx := cmd.Context()
+
+		cfg, err := config.Load(ackConfigPath)
+		if err != nil {
+			return err
+		}
+
+		// Check it doesn't already exist in the configuration
+		if util.InStrings(service, cfg.Repositories.Services) {
+			return ErrRepositoryAlreadyAdded
+		}
+
+		repoManager, err := repository.NewManager(cfg)
+		if err != nil {
+			return err
+		}
+
+		serviceRepoName := fmt.Sprintf("%s-controller", service)
+		if err := repoManager.EnsureRepository(ctx, serviceRepoName); err != nil {
+			return err
+		}
+
+		cfg.Repositories.Services = append(cfg.Repositories.Services, service)
+		config.Save(cfg, ackConfigPath)
+	}
+
+	return nil
+}

--- a/cmd/ackdev/cmd/root.go
+++ b/cmd/ackdev/cmd/root.go
@@ -29,6 +29,7 @@ func init() {
 
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(editCmd)
+	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(setupCmd)
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -21,9 +21,6 @@ import (
 
 // NewRepository returns a pointer to a new repository.
 func NewRepository(name string, repoType RepositoryType) *Repository {
-	if repoType == RepositoryTypeController {
-		name = fmt.Sprintf("%s-controller", name)
-	}
 	return &Repository{
 		Name: name,
 		Type: repoType,


### PR DESCRIPTION
Description of changes:
Adds a new set of commands under the `add` verb. The first of which is `add repository` (or `add repo`) command. This will ensure the fork and clone, and then add the repository to the configuration file.

This should greatly reduce the amount of time to set up new repositories locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
