### PR TITLE
Add `ensure repositories` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,48 @@ kustomize      OK        v4.0.1          /usr/local/bin/kustomize
 controller-gen OK        v0.4.0          /usr/bin/controller-gen
 ```
 
+#### Managed repositories
+
+`ackdev` can help manage the repositories you need to interact with in your ACK
+development journey. To list all the repositories that you have configured, you
+can run:
+
+```bash
+ackdev list repos # repo|repository|repositories [--filter|--show-branch]
+```
+
+The output will look like this:
+```bash
+NAME                   TYPE       BRANCH 
+test-infra             core       main   
+runtime                core       main   
+code-generator         core       main   
+dev-tools              core       main   
+dynamodb-controller    controller main   
+ecr-controller         controller main   
+s3-controller          controller main   
+eks-controller         controller main   
+sqs-controller         controller main   
+s3-controller          controller main   
+mq-controller          controller main   
+elasticache-controller controller main
+```
+
+You can filter repositories by name, type, branch or name prefix. e.g `--filter=type=controller`
+
+To configure and ensure (fork+clone) a new repository you can run:
+
+```bash
+ackdev add repo eks --type=controller
+```
+
+To ensure that all the configured repositories are forked in your github account
+and cloned in your local GOPATH, you can run:
+
+```bash
+ackdev ensure repos
+```
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/cmd/ackdev/cmd/ensure.go
+++ b/cmd/ackdev/cmd/ensure.go
@@ -1,0 +1,28 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	ensureCmd.AddCommand(ensureRepositoriesCmd)
+}
+
+var ensureCmd = &cobra.Command{
+	Use:   "ensure",
+	Args:  cobra.NoArgs,
+	Short: "Ensure repositories or dependencies",
+}

--- a/cmd/ackdev/cmd/ensure_repos.go
+++ b/cmd/ackdev/cmd/ensure_repos.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aws-controllers-k8s/dev-tools/pkg/config"
+	"github.com/aws-controllers-k8s/dev-tools/pkg/repository"
+)
+
+var ensureRepositoriesCmd = &cobra.Command{
+	Use:     "repo",
+	Aliases: []string{"repos", "repositories", "repository"},
+	RunE:    ensureAllRepositories,
+	Args:    cobra.NoArgs,
+	Short:   "Ensure repositories are forked and cloned locally",
+}
+
+func ensureAllRepositories(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load(ackConfigPath)
+	if err != nil {
+		return err
+	}
+
+	repoManager, err := repository.NewManager(cfg)
+	if err != nil {
+		return err
+	}
+
+	err = repoManager.LoadAll()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	return repoManager.EnsureAll(ctx)
+}

--- a/cmd/ackdev/cmd/root.go
+++ b/cmd/ackdev/cmd/root.go
@@ -32,6 +32,7 @@ func init() {
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(setupCmd)
+	rootCmd.AddCommand(ensureCmd)
 }
 
 var rootCmd = &cobra.Command{

--- a/pkg/repository/manager_test.go
+++ b/pkg/repository/manager_test.go
@@ -164,7 +164,9 @@ func TestManager_LoadAll(t *testing.T) {
 				git:       fakeGit,
 				repoCache: make(map[string]*Repository),
 			},
-			wantErr: true,
+			// `ackdev list repositories` should not hide non cloned repositories.
+			// It should just show that there are no active branches locally.
+			wantErr: false,
 		},
 		{
 			name: "unexpected repository error",


### PR DESCRIPTION
Issue N/A

Description of changes:
This patch introduces a new subcommand to ensure that configured services
or core repositories are forked and cloned locally.
In addition to that, this patch also fixes a sneaky bug that was
preventing `ackdev list repos` from showing non-cloned repositories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
