### PR TITLE
Ensure git remotes for local repositories

### DIFF
--- a/pkg/util/git.go
+++ b/pkg/util/git.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"fmt"
+
+	git "gopkg.in/src-d/go-git.v4"
+	gitconfig "gopkg.in/src-d/go-git.v4/config"
+)
+
+// GetRepositoryRemotes returns a map containing the remote names and the URLs they
+// point to.
+func GetRepositoryRemotes(repo *git.Repository) (map[string][]string, error) {
+	gitRemotes, err := repo.Remotes()
+	if err != nil {
+		return nil, fmt.Errorf("cannot list remotes: %v", err)
+	}
+
+	remotes := map[string][]string{}
+	for _, remote := range gitRemotes {
+		remoteCfg := remote.Config()
+		remotes[remoteCfg.Name] = remoteCfg.URLs
+	}
+	return remotes, nil
+}
+
+// UpdateRepositoryRemotes updates the URLs list for a specific remote.
+func UpdateRepositoryRemotes(repo *git.Repository, name string, URLs []string) error {
+	cfg, err := repo.Storer.Config()
+	if err != nil {
+		return err
+	}
+
+	cfg.Remotes[name] = &gitconfig.RemoteConfig{
+		Name: name,
+		URLs: URLs,
+	}
+	return repo.Storer.SetConfig(cfg)
+}


### PR DESCRIPTION
Issue N/A

Description of changes:
This patch adds more logic to `pkg/repository.Manager` to ensure that
the local repositories remotes point to the right URLs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
