### PR TITLE
Scope down GitHub token permissions for unit-tests.yaml

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -9,6 +9,10 @@ on:
       - go.mod
       - go.sum
 
+
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: make test


### PR DESCRIPTION
Issue #, if available:

Description of changes: Scope down GitHub token to least privilege necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
